### PR TITLE
[openthread] add timeouts and intervals

### DIFF
--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -2,6 +2,7 @@
 #ifdef USE_OPENTHREAD
 #include "openthread.h"
 
+#include <openthread/child_supervision.h>
 #include <openthread/cli.h>
 #include <openthread/instance.h>
 #include <openthread/logging.h>
@@ -309,6 +310,15 @@ void OpenThreadComponent::apply_linkmode(otInstance *instance) {
     }
     ESP_LOGD(TAG, "Link Polling Period: %" PRIu32, otLinkGetPollPeriod(instance));
   }
+
+  uint16_t poll_period_sec = (this->poll_period_ + 500) / 1000;
+  otThreadSetChildTimeout(instance, std::max(poll_period_sec * 4, 240));
+  otChildSupervisionSetCheckTimeout(instance, std::max(poll_period_sec * 2, 129));
+  otChildSupervisionSetInterval(instance, std::max((uint16_t) (poll_period_sec * 1.5), (uint16_t) 190));
+  ESP_LOGD(TAG, "Child Timeout: %d sec, Child Supervision Check Timeout: %d sec, Child Supervision Interval: %d sec",
+           otThreadGetChildTimeout(instance), otChildSupervisionGetCheckTimeout(instance),
+           otChildSupervisionGetInterval(instance));
+
   link_mode_config.mRxOnWhenIdle = this->poll_period_ == 0;
   link_mode_config.mDeviceType = false;
   link_mode_config.mNetworkData = false;

--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -313,8 +313,8 @@ void OpenThreadComponent::apply_linkmode(otInstance *instance) {
 
   uint16_t poll_period_sec = (this->poll_period_ + 500) / 1000;
   otThreadSetChildTimeout(instance, std::max(poll_period_sec * 4, 240));
-  otChildSupervisionSetCheckTimeout(instance, std::max(poll_period_sec * 2, 129));
-  otChildSupervisionSetInterval(instance, std::max((uint16_t) (poll_period_sec * 1.5), (uint16_t) 190));
+  otChildSupervisionSetCheckTimeout(instance, std::max(poll_period_sec * 2, 190));
+  otChildSupervisionSetInterval(instance, std::max((uint16_t) (poll_period_sec * 1.5), (uint16_t) 129));
   ESP_LOGD(TAG, "Child Timeout: %d sec, Child Supervision Check Timeout: %d sec, Child Supervision Interval: %d sec",
            otThreadGetChildTimeout(instance), otChildSupervisionGetCheckTimeout(instance),
            otChildSupervisionGetInterval(instance));


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
When a device is an MTD, this PR sets new values for Child Timeout, Child Supervision Check Timeout, and Child Supervision Interval based on poll_period.  This allows device to have poll periods greater than 180 seconds without detaching from parent.

The original defaults are used as the minimum possible values:

* Child Timeout - the maximum of 240 seconds and 4 * poll_period in seconds
* Child Supervision Check Timeout - the maximum of 190 seconds and 2 * poll_period in seconds
* Child Supervision Interval - the maximum of 129 seconds and 1.5 * poll_period in seconds

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
